### PR TITLE
Allow single results from google

### DIFF
--- a/paperscraper/lib.py
+++ b/paperscraper/lib.py
@@ -872,7 +872,8 @@ async def a_gsearch_papers(  # noqa: C901, PLR0915
             return paper
 
         papers = await asyncio.gather(*[process(p) for p in papers])
-        total_papers = data["search_information"]["total_results"]
+        # single results (i.e. a DOI given as the query string, don't have total_results fields)
+        total_papers = data["search_information"].get("total_results", 1)
         logger.info(
             f"Found {total_papers} papers, analyzing {_offset} to {_offset + len(papers)}"
         )


### PR DESCRIPTION
Google sometimes returns a single result, i.e. in an exact title or DOI search. I this case we saw key errors, and this will fix that.